### PR TITLE
Bump org.jmock:jmock-junit4 from 2.6.0 to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <agrona.version>1.6.0</agrona.version>
     <junit.version>5.10.1</junit.version>
     <byteman.version>4.0.22</byteman.version>
-    <jmock.version>2.6.0</jmock.version>
+    <jmock.version>2.12.0</jmock.version>
     <mockito.version>5.8.0</mockito.version>
     <k3po.version>3.1.0</k3po.version>
     <jmh.version>1.37</jmh.version>


### PR DESCRIPTION
pr_rerun dependabot/maven/org.jmock-jmock-junit4-2.12.0 to develop