### PR TITLE
Bump eclipse-temurin from 20-alpine to 21-alpine in /cloud/docker-image/src/main/docker/release

### DIFF
--- a/cloud/docker-image/src/main/docker/release/Dockerfile
+++ b/cloud/docker-image/src/main/docker/release/Dockerfile
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-FROM eclipse-temurin:20-jdk AS build
+FROM eclipse-temurin:21-jdk AS build
 
 RUN apt update && apt install -y gettext
 

--- a/cloud/docker-image/src/main/docker/release/alpine.Dockerfile
+++ b/cloud/docker-image/src/main/docker/release/alpine.Dockerfile
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-FROM eclipse-temurin:20-alpine AS build
+FROM eclipse-temurin:21-alpine AS build
 
 COPY maven /root/.m2/repository
 


### PR DESCRIPTION
pr_rerun dependabot/docker/cloud/docker-image/src/main/docker/release/eclipse-temurin-21-alpine to develop