### PR TITLE
Ensure binding types are populated for `zilla dump` to dissect protocol-specific frames

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -903,7 +903,11 @@ public class EngineWorker implements EngineContext, Agent
         taskQueue.offer(attachTask);
         signaler.signalNow(0L, 0L, 0L, supplyTraceId(), SIGNAL_TASK_QUEUED, 0);
 
-        writeBindingTypes(registry);
+        if (localIndex == 0)
+        {
+            attachTask.future().join();
+            writeBindingTypes(registry);
+        }
 
         return attachTask.future();
     }
@@ -917,8 +921,11 @@ public class EngineWorker implements EngineContext, Agent
         taskQueue.offer(detachTask);
         signaler.signalNow(0L, 0L, 0L, supplyTraceId(), SIGNAL_TASK_QUEUED, 0);
 
-        writeBindingTypes(registry);
-
+        if (localIndex == 0)
+        {
+            detachTask.future().join();
+            writeBindingTypes(registry);
+        }
         return detachTask.future();
     }
 


### PR DESCRIPTION
pr_rerun QDinsight:dump-fix to develop