### PR TITLE
Bump eclipse-temurin from 20-jdk to 21-jdk in /cloud/docker-image/src/main/docker/incubator

### DIFF
--- a/cloud/docker-image/src/main/docker/incubator/Dockerfile
+++ b/cloud/docker-image/src/main/docker/incubator/Dockerfile
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-FROM eclipse-temurin:20-jdk AS build
+FROM eclipse-temurin:21-jdk AS build
 
 RUN apt update && apt install -y gettext
 


### PR DESCRIPTION
pr_rerun dependabot/docker/cloud/docker-image/src/main/docker/incubator/eclipse-temurin-21-jdk to develop