### PR TITLE
Support `http-kafka` header overrides from AsyncAPI http operation

### DIFF
--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiHttpKafkaProxy.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiHttpKafkaProxy.java
@@ -352,6 +352,14 @@ public class AsyncapiHttpKafkaProxy extends AsyncapiProxy
         AsyncapiBinding httpKafkaBinding = httpOperation.bindings.get("x-zilla-http-kafka");
         if (httpKafkaBinding != null)
         {
+            String httpKafkaKey = httpKafkaBinding.key;
+            if (httpKafkaKey != null)
+            {
+                httpKafkaKey = AsyncapiIdentity.resolve(namespace, httpKafkaKey);
+
+                produce.key(httpKafkaKey);
+            }
+
             Map<String, String> overrides = httpKafkaBinding.overrides;
             if (overrides != null)
             {
@@ -360,12 +368,7 @@ public class AsyncapiHttpKafkaProxy extends AsyncapiProxy
                     String name = override.getKey();
                     String value = override.getValue();
 
-                    // TODO: generate "jwt0" guard via security scheme
-                    //       then use knowledge of generated guard name
-                    if ("{identity}".equals(value))
-                    {
-                        value = String.format("${guarded['%s:jwt0'].identity}", namespace);
-                    }
+                    value = AsyncapiIdentity.resolve(namespace, value);
 
                     produce.override()
                         .name(name)

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiIdentity.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiIdentity.java
@@ -12,14 +12,23 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package io.aklivity.zilla.runtime.binding.asyncapi.internal.model;
+package io.aklivity.zilla.runtime.binding.asyncapi.internal.config;
 
-import java.util.Map;
-
-public class AsyncapiBinding
+public final class AsyncapiIdentity
 {
-    public String method;
+    public static String resolve(
+        String namespace,
+        String value)
+    {
+        if ("{identity}".equals(value))
+        {
+            value = String.format("${guarded['%s:jwt0'].identity}", namespace);
+        }
 
-    public String key;
-    public Map<String, String> overrides;
+        return value;
+    }
+
+    private AsyncapiIdentity()
+    {
+    }
 }

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiMqttKafkaProxy.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiMqttKafkaProxy.java
@@ -47,7 +47,7 @@ public class AsyncapiMqttKafkaProxy extends AsyncapiProxy
     @Override
     protected <C> BindingConfigBuilder<C> injectProxyRoutes(
         BindingConfigBuilder<C> binding,
-        List<AsyncapiRouteConfig> routes)
+        String namespace, List<AsyncapiRouteConfig> routes)
     {
         inject:
         for (AsyncapiRouteConfig route : routes)

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiProxy.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiProxy.java
@@ -39,6 +39,7 @@ public abstract class AsyncapiProxy
 
     protected abstract <C> BindingConfigBuilder<C> injectProxyRoutes(
         BindingConfigBuilder<C> binding,
+        String namespace,
         List<AsyncapiRouteConfig> routes);
 
     public abstract <C> BindingConfigBuilder<C> injectProxyOptions(

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiProxyNamespaceGenerator.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiProxyNamespaceGenerator.java
@@ -95,7 +95,7 @@ public class AsyncapiProxyNamespaceGenerator extends AsyncapiNamespaceGenerator
                 .kind(PROXY)
                 .inject(b -> this.injectMetrics(b, metricRefs))
                 .inject(b -> proxy.injectProxyOptions(b, options))
-                .inject(b -> proxy.injectProxyRoutes(b, r))
+                .inject(b -> proxy.injectProxyRoutes(b, null, r))
                 .build();
         });
 

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiProxyNamespaceGenerator.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiProxyNamespaceGenerator.java
@@ -86,6 +86,7 @@ public class AsyncapiProxyNamespaceGenerator extends AsyncapiNamespaceGenerator
             .name(String.format("%s/%s", qname, namespace))
             .inject(n -> this.injectNamespaceMetric(n, !metricRefs.isEmpty()));
 
+        String ns = binding.namespace;
         routesByProtocol.forEach((k, r) ->
         {
             final AsyncapiProxy proxy = resolveProxy(k);
@@ -95,7 +96,7 @@ public class AsyncapiProxyNamespaceGenerator extends AsyncapiNamespaceGenerator
                 .kind(PROXY)
                 .inject(b -> this.injectMetrics(b, metricRefs))
                 .inject(b -> proxy.injectProxyOptions(b, options))
-                .inject(b -> proxy.injectProxyRoutes(b, null, r))
+                .inject(b -> proxy.injectProxyRoutes(b, ns, r))
                 .build();
         });
 

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiSseKafkaProxy.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiSseKafkaProxy.java
@@ -45,6 +45,7 @@ public class AsyncapiSseKafkaProxy extends AsyncapiProxy
     @Override
     protected <C> BindingConfigBuilder<C> injectProxyRoutes(
         BindingConfigBuilder<C> binding,
+        String namespace,
         List<AsyncapiRouteConfig> routes)
     {
         inject:

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiBinding.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiBinding.java
@@ -14,7 +14,11 @@
  */
 package io.aklivity.zilla.runtime.binding.asyncapi.internal.model;
 
+import java.util.Map;
+
 public class AsyncapiBinding
 {
     public String method;
+
+    public Map<String, String> overrides;
 }

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiKafkaFilter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiKafkaFilter.java
@@ -14,15 +14,10 @@
  */
 package io.aklivity.zilla.runtime.binding.asyncapi.internal.model;
 
-import java.util.List;
 import java.util.Map;
 
-public class AsyncapiBinding
+public class AsyncapiKafkaFilter
 {
-    public String method;
-
     public String key;
-    public Map<String, String> overrides;
-
-    public List<AsyncapiKafkaFilter> filters;
+    public Map<String, String> headers;
 }

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchConfigBuilder.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.http.kafka.config;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -39,6 +40,11 @@ public final class HttpKafkaWithFetchConfigBuilder<T> extends ConfigBuilder<T, H
         return this;
     }
 
+    public HttpKafkaWithFetchFilterConfigBuilder<HttpKafkaWithFetchConfigBuilder<T>> filter()
+    {
+        return new HttpKafkaWithFetchFilterConfigBuilder<>(this::filter);
+    }
+
     public HttpKafkaWithFetchConfigBuilder<T> filters(
          List<HttpKafkaWithFetchFilterConfig> filters)
     {
@@ -60,10 +66,21 @@ public final class HttpKafkaWithFetchConfigBuilder<T> extends ConfigBuilder<T, H
         return (Class<HttpKafkaWithFetchConfigBuilder<T>>) getClass();
     }
 
-
     @Override
     public T build()
     {
         return mapper.apply(new HttpKafkaWithFetchConfig(topic, filters, merge));
+    }
+
+    private HttpKafkaWithFetchConfigBuilder<T> filter(
+        HttpKafkaWithFetchFilterConfig filter)
+    {
+        if (filters == null)
+        {
+            filters = new LinkedList<>();
+        }
+
+        filters.add(filter);
+        return this;
     }
 }

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceConfigBuilder.java
@@ -15,6 +15,7 @@
 package io.aklivity.zilla.runtime.binding.http.kafka.config;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -59,6 +60,11 @@ public final class HttpKafkaWithProduceConfigBuilder<T> extends ConfigBuilder<T,
         return this;
     }
 
+    public HttpKafkaWithProduceOverrideConfigBuilder<HttpKafkaWithProduceConfigBuilder<T>> override()
+    {
+        return new HttpKafkaWithProduceOverrideConfigBuilder<>(this::override);
+    }
+
     public HttpKafkaWithProduceConfigBuilder<T> overrides(
         List<HttpKafkaWithProduceOverrideConfig> overrides)
     {
@@ -101,10 +107,21 @@ public final class HttpKafkaWithProduceConfigBuilder<T> extends ConfigBuilder<T,
         return (Class<HttpKafkaWithProduceConfigBuilder<T>>) getClass();
     }
 
-
     @Override
     public T build()
     {
         return mapper.apply(new HttpKafkaWithProduceConfig(topic, acks, key, overrides, replyTo, async));
+    }
+
+    private HttpKafkaWithProduceConfigBuilder<T> override(
+        HttpKafkaWithProduceOverrideConfig override)
+    {
+        if (overrides == null)
+        {
+            overrides = new LinkedList<>();
+        }
+
+        overrides.add(override);
+        return this;
     }
 }

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.yaml
@@ -53,6 +53,10 @@ catalogs:
             bindings:
               http:
                 method: POST
+              x-zilla-http-kafka:
+                overrides:
+                  zilla:command: CreatePet
+                  zilla:identity: "{identity}"
             channel:
               $ref: '#/channels/pets'
           listPets:

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/proxy.http.create.pet/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/proxy.http.create.pet/server.rpt
@@ -31,6 +31,7 @@ read zilla:begin.ext ${openapi:beginEx()
                                   .header(":authority", "localhost:8080")
                                   .header("content-type", "application/json")
                                   .header("content-length", "39")
+                                  .header("zilla:command", "CreatePet")
                                   .build())
                              .build()}
 


### PR DESCRIPTION
pr_rerun QDinsight:asyncapi-http-kafka-overrides to develop