### PR TITLE
Bump com.google.protobuf:protobuf-java-util from 3.24.4 to 4.27.1

### DIFF
--- a/runtime/model-protobuf/pom.xml
+++ b/runtime/model-protobuf/pom.xml
@@ -49,7 +49,7 @@
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java-util</artifactId>
-    <version>3.24.4</version>
+    <version>4.27.1</version>
   </dependency>
   <dependency>
     <groupId>org.antlr</groupId>


### PR DESCRIPTION
pr_rerun dependabot/maven/com.google.protobuf-protobuf-java-util-4.27.1 to develop