### PR TITLE
Bump org.glassfish.jaxb:jaxb-runtime from 2.3.3 to 4.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
             <dependency>
               <groupId>org.glassfish.jaxb</groupId>
               <artifactId>jaxb-runtime</artifactId>
-              <version>2.3.3</version>
+              <version>4.0.4</version>
             </dependency>
           </dependencies>
           <configuration>


### PR DESCRIPTION
pr_rerun dependabot/maven/org.glassfish.jaxb-jaxb-runtime-4.0.4 to develop