### PR TITLE
Bump eclipse-temurin from 20-jdk to 21-jdk in /cloud/docker-image/src/main/docker/incubator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,21 +10,21 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ 11, 17, 20 ]
+        java: [ 20 ]
 
     steps:
     - name: Checkout GitHub sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository

--- a/cloud/docker-image/src/main/docker/incubator/Dockerfile
+++ b/cloud/docker-image/src/main/docker/incubator/Dockerfile
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-FROM eclipse-temurin:20-jdk AS build
+FROM eclipse-temurin:21-jdk AS build
 
 RUN apt update && apt install -y gettext
 


### PR DESCRIPTION
pr_rerun dependabot/docker/cloud/docker-image/src/main/docker/incubator/eclipse-temurin-21-jdk to develop