### PR TITLE
Bump org.jmock:jmock-junit4 from 2.6.0 to 2.13.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,16 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ 11, 17, 20 ]
+        java: [ 17, 20 ]
 
     steps:
     - name: Checkout GitHub sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <slf4j.version>1.7.36</slf4j.version>
     <junit.version>5.10.1</junit.version>
     <byteman.version>4.0.22</byteman.version>
-    <jmock.version>2.6.0</jmock.version>
+    <jmock.version>2.13.0</jmock.version>
     <mockito.version>5.8.0</mockito.version>
     <k3po.version>3.1.0</k3po.version>
     <jmh.version>1.37</jmh.version>


### PR DESCRIPTION
pr_rerun dependabot/maven/org.jmock-jmock-junit4-2.13.0 to develop