### PR TITLE
Bump org.bitbucket.b_c:jose4j from 0.9.3 to 0.9.4 in /runtime/guard-jwt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,16 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ 11, 17, 20 ]
+        java: [ 20 ]
 
     steps:
     - name: Checkout GitHub sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}

--- a/runtime/guard-jwt/pom.xml
+++ b/runtime/guard-jwt/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.bitbucket.b_c</groupId>
       <artifactId>jose4j</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
pr_rerun dependabot/maven/runtime/guard-jwt/org.bitbucket.b_c-jose4j-0.9.4 to develop