### PR TITLE
Reset back initial max once ack is fully caught up with seq

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
@@ -1590,7 +1590,8 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
             long acknowledge)
         {
             cursor.advance(partitionOffset);
-            doClientInitialWindow(traceId, initialSeq - acknowledge, initialMax);
+            doClientInitialWindow(traceId, initialSeq - acknowledge,
+                Math.max(initialMax - (int) (acknowledge - initialAck), initialBudgetMax));
 
             if (KafkaState.initialClosed(state) && partitionOffset == this.partitionOffset)
             {

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
@@ -1446,7 +1446,7 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                 initialAck = newInitialAck;
                 assert initialAck <= initialSeq;
 
-                initialMax = minInitialMax;
+                initialMax = minInitialNoAck == 0 ? initialBudgetMax : minInitialMax;
 
                 state = KafkaState.openedInitial(state);
 


### PR DESCRIPTION
pr_rerun QDinsight:bug/kafka-produce to develop