### PR TITLE
Bump com.google.protobuf:protobuf-java-util from 3.24.4 to 4.27.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,16 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ 17, 21, 22 ]
+        java: [ 22 ]
 
     steps:
     - name: Checkout GitHub sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}

--- a/runtime/model-protobuf/pom.xml
+++ b/runtime/model-protobuf/pom.xml
@@ -49,7 +49,7 @@
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java-util</artifactId>
-    <version>3.24.4</version>
+    <version>4.27.1</version>
   </dependency>
   <dependency>
     <groupId>org.antlr</groupId>


### PR DESCRIPTION
pr_rerun dependabot/maven/com.google.protobuf-protobuf-java-util-4.27.1 to develop